### PR TITLE
docs: add MIT license and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kazuki Nagasawa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,46 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Kazuki's Homepage
 
-## Getting Started
+Personal portfolio website built with Next.js and Chakra UI.
 
-First, run the development server:
+## Stack
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+- [Next.js](https://nextjs.org/) - React framework
+- [Chakra UI](https://chakra-ui.com/) - Component library
+- [TypeScript](https://typescriptlang.org/) - Type safety
+- [next-themes](https://github.com/pacocoursey/next-themes) - Theme switching
+
+## Project structure
+
+```
+$PROJECT_ROOT
+│   # Page files
+├── app
+│   ├── layout.tsx          # Root layout
+│   ├── page.tsx            # Homepage
+│   ├── providers.tsx       # App providers
+│   │
+│   │   # UI components
+│   ├── components
+│   │   ├── shared          # Shared components
+│   │   ├── HeroSection.tsx
+│   │   ├── WorkSection.tsx
+│   │   └── ...
+│   │
+│   │   # Non-page modules
+│   ├── lib                 # Configuration & utilities
+│   ├── types               # TypeScript definitions
+│   └── constants           # App constants
+│
+│   # Static files
+└── public
+    └── images
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## License
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+MIT License.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+You can create your own homepage for free without notifying me by forking this project under the following conditions:
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- Add a link to my homepage
+- Check out [LICENSE](LICENSE) for more detail.


### PR DESCRIPTION
 ## Summary
  - Add MIT License file with proper copyright notice
  - Update README from default Next.js template to portfolio-specific documentation
  - Add project structure documentation and licensing terms for forking

  ## Test plan
  - [ ] Verify LICENSE file displays correctly on GitHub
  - [ ] Confirm README renders properly in repository view
  - [ ] Check that all links in README work correctly