### PR TITLE
fix: resolve mobile theme toggle icon mismatch

### DIFF
--- a/app/components/shared/Navigation.tsx
+++ b/app/components/shared/Navigation.tsx
@@ -12,11 +12,14 @@ import NextLink from "next/link";
 import { personalInfo } from "../../config/profile";
 import { THEME_DARK, THEME_LIGHT } from "../../constants/theme";
 import { useAppTheme } from "../../context/ThemeContext";
+import { getActualTheme } from "../../lib/themeUtils";
 
 export function Navigation() {
-  const { themeConfig, mounted, setTheme, resolvedTheme } = useAppTheme();
+  const { themeConfig, mounted, setTheme, resolvedTheme, theme } =
+    useAppTheme();
   const { borderColor, textColor, mutedColor, accentColor, navBg } =
     themeConfig;
+  const actualTheme = getActualTheme(mounted, theme, resolvedTheme);
 
   return (
     <Box
@@ -57,7 +60,7 @@ export function Navigation() {
             <IconButton
               aria-label={personalInfo.navigation.themeToggleLabel}
               onClick={() => {
-                const isDark = mounted ? resolvedTheme === THEME_DARK : false;
+                const isDark = actualTheme === THEME_DARK;
                 setTheme(isDark ? THEME_LIGHT : THEME_DARK);
               }}
               size="sm"
@@ -65,18 +68,14 @@ export function Navigation() {
               color={accentColor}
               _hover={{
                 bg:
-                  mounted && resolvedTheme === THEME_DARK
+                  actualTheme === THEME_DARK
                     ? "whiteAlpha.200"
                     : "blackAlpha.100",
                 transform: "rotate(180deg)",
               }}
               transition="all 0.3s"
             >
-              {mounted && resolvedTheme === THEME_DARK ? (
-                <IoSunnyOutline />
-              ) : (
-                <IoMoon />
-              )}
+              {actualTheme === THEME_DARK ? <IoSunnyOutline /> : <IoMoon />}
             </IconButton>
           </HStack>
         </Flex>

--- a/app/constants/theme.ts
+++ b/app/constants/theme.ts
@@ -1,2 +1,6 @@
 export const THEME_LIGHT = "light";
 export const THEME_DARK = "dark";
+export const THEME_SYSTEM = "system";
+export const COLORS = {
+  GRAY_900_RGB: "rgb(17, 24, 39)",
+};

--- a/app/lib/themeUtils.ts
+++ b/app/lib/themeUtils.ts
@@ -1,0 +1,22 @@
+import {
+  THEME_DARK,
+  THEME_LIGHT,
+  THEME_SYSTEM,
+  COLORS,
+} from "../constants/theme";
+
+export function getActualTheme(
+  mounted: boolean,
+  theme: string | undefined,
+  resolvedTheme: string | undefined,
+): string {
+  if (!mounted) return THEME_LIGHT;
+
+  if (theme === THEME_SYSTEM) {
+    const rootStyle = window.getComputedStyle(document.documentElement);
+    const bgColor = rootStyle.backgroundColor;
+    return bgColor === COLORS.GRAY_900_RGB ? THEME_DARK : THEME_LIGHT;
+  }
+
+  return resolvedTheme || THEME_LIGHT;
+}


### PR DESCRIPTION
## Summary
  Fixes theme toggle icon showing incorrect state on mobile devices when system theme is enabled.

  ## Problem
  On mobile devices with system theme preference, the theme toggle was showing sun icon (☀️) for light mode instead of moon icon (🌙), causing user confusion about which mode would be toggled to.

  **Before:**
  - Mobile (light mode): ☀️ (incorrect)
  - PC (light mode): 🌙 (correct)

  **After:**
  - Mobile (light mode): 🌙 (correct)
  - PC (light mode): 🌙 (correct)

  ## Changes
  ### Bug Fix
  - Fix theme detection logic for `theme="system"` case
  - Use actual computed styles instead of `resolvedTheme` for accurate detection
  - Ensure consistent icon display across all device types

  ### Code Quality Improvements
  - Add `THEME_SYSTEM` and `COLORS` constants to eliminate hardcoded strings
  - Extract `getActualTheme` utility function to `lib/themeUtils.ts`
  - Improve code maintainability and testability
  - Remove inline theme detection logic from Navigation component

  ## Test plan
  - [x] Verify theme toggle works correctly on mobile devices
  - [x] Test system theme detection accuracy
  - [x] Ensure consistent behavior across PC and mobile
  - [x] Check icon display matches current theme state

  ## Files Changed
  - `app/components/shared/Navigation.tsx` - Updated theme toggle logic
  - `app/constants/theme.ts` - Added theme and color constants
  - `app/lib/themeUtils.ts` - New utility for theme detection